### PR TITLE
added LoadPCD.srv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation ${MESSAGE_DEPENDS})
 add_service_files(
   FILES
     ResizeParticle.srv
+    LoadPCD.srv
 )
 add_message_files(
   FILES

--- a/srv/LoadPCD.srv
+++ b/srv/LoadPCD.srv
@@ -1,0 +1,3 @@
+string pcd_path
+---
+bool success


### PR DESCRIPTION
Service definition accompanies other pull request in mcl_3dl: https://github.com/at-wat/mcl_3dl/pull/381

The map to localize in was previously loaded with a sensor_msgs::PointCloud2 topic. It was not guaranteed that the map was actually loaded with a single publish on the topic. Also it was overkill if you had a pcd you wanted to localize in, because you would have to convert it first to a PointCloud2, then publish it, and then it would be converted in mcl_3dl to a PCL cloud.

This service facilitates loading a pcd file by file path, directly into mcl_3dl.