### PR TITLE
Update required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.26)
+cmake_minimum_required(VERSION 2.8...3.26)
 project(mcl_3dl_msgs)
 
 set(MESSAGE_DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.3...3.26)
 project(mcl_3dl_msgs)
 
 set(MESSAGE_DEPENDS


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.26 to avoid error/warning on the latest cmake.
CMake 4.0 dropped 3.5 and marked 3.10 as deprecated.